### PR TITLE
Setting name case

### DIFF
--- a/tests/data/WARNING-LoggingSettingNameCaseViolation/process.ini
+++ b/tests/data/WARNING-LoggingSettingNameCaseViolation/process.ini
@@ -1,0 +1,22 @@
+##########################################################################
+###			PROCESS FILE
+### 			Version vXX.YYYYMMDD.ZZ
+##########################################################################
+
+[states]
+
+[transitions]
+
+[CPM Parameters Validation]
+
+[parameters]
+PromptTimeout=60
+SendHumanMin=1
+SendHumanMax=2
+
+[Debug Information]
+DebugLogFullParsingInfo=no
+DebugLogFullExecutionInfo=no
+DebugLogDetailBuiltInActions=no
+ExpectLog=no
+COnsoleOutput=no

--- a/tests/test_logging_rule_sets.py
+++ b/tests/test_logging_rule_sets.py
@@ -48,6 +48,18 @@ class TestLoggingRuleSets(object):
                 ],
             ),
             (
+                'tests/data/WARNING-LoggingSettingNameCaseViolation/process.ini',
+                'tests/data/empty_prompts.ini',
+                True,
+                [
+                    ValidationResult(
+                        rule='LoggingSettingNameCaseViolation',
+                        severity=Severity.WARNING,
+                        message='The logging setting "COnsoleOutput" should be set as "ConsoleOutput".',
+                    ),
+                ],
+            ),
+            (
                 'tests/data/OK-logging/process.ini',
                 'tests/data/empty_prompts.ini',
                 True,

--- a/tpc_plugin_validator/rule_sets/logging.py
+++ b/tpc_plugin_validator/rule_sets/logging.py
@@ -45,15 +45,22 @@ class Logging(RuleSet):
             'ExpectLog',
             'ConsoleOutput',
         ]
-        # TODO check if the name of the setting is in the wrong case.
-        if setting not in valid_settings:
-            self._add_violation(
-                name='LoggingSettingNameViolation',
-                description=f'The logging setting "{setting}" is not a valid logging setting. Valid settings are: {", ".join(valid_settings)}.',
-                severity=Severity.WARNING,
-            )
-            return False
-        return True
+        if setting in valid_settings:
+            return True
+        for valid_setting in valid_settings:
+            if setting.lower() == valid_setting.lower():
+                self._add_violation(
+                    name='LoggingSettingNameCaseViolation',
+                    description=f'The logging setting "{setting}" should be set as "{valid_setting}".',
+                    severity=Severity.WARNING,
+                )
+                return False
+        self._add_violation(
+            name='LoggingSettingNameViolation',
+            description=f'The logging setting "{setting}" is not a valid logging setting. Valid settings are: {", ".join(valid_settings)}.',
+            severity=Severity.WARNING,
+        )
+        return False
 
     def _check_setting_value(self, setting: str, value: str) -> None:
         """


### PR DESCRIPTION
Added a violation to handle setting names being in the wrong case.

## Summary by Sourcery

Introduce a new validation rule to flag logging setting names with incorrect casing and update the test suite with a corresponding test case and sample data

New Features:
- Add a new LoggingSettingNameCaseViolation for logging settings that match by name but use incorrect casing

Enhancements:
- Enhance the logging settings checker to detect and report case mismatches separately from invalid names

Tests:
- Add a test case and sample INI file for the LoggingSettingNameCaseViolation scenario