### PR TITLE
Refactored token names and used these for the valid token in rule sets

### DIFF
--- a/tpc_plugin_validator/lexer/utilities/token_name.py
+++ b/tpc_plugin_validator/lexer/utilities/token_name.py
@@ -5,9 +5,9 @@ from enum import Enum
 
 class TokenName(Enum):
     """CLass to hold the token name."""
-    ASSIGNMENT = 'ASSIGNMENT'
-    COMMENT = 'COMMENT'
-    FAIL_STATE = 'FAIL_STATE'
-    CPM_PARAMETER_VALIDATION = 'CPM_PARAMETER_VALIDATION'
-    SECTION_HEADER = 'SECTION_HEADER'
-    STATE_TRANSITION = 'STATE_TRANSITION'
+    ASSIGNMENT = 'Assignment'
+    COMMENT = 'Comment'
+    FAIL_STATE = 'FAIL STATE'
+    CPM_PARAMETER_VALIDATION = 'CPM Parameter Validation'
+    SECTION_HEADER = 'Section Header'
+    STATE_TRANSITION = 'State Transition'

--- a/tpc_plugin_validator/rule_sets/cpm_parameter.py
+++ b/tpc_plugin_validator/rule_sets/cpm_parameter.py
@@ -3,10 +3,14 @@ from tpc_plugin_validator.lexer.tokens.cpm_parameter_validation import \
     CPMParameterValidation
 from tpc_plugin_validator.rule_sets.rule_set import RuleSet
 from tpc_plugin_validator.utilities.severity import Severity
+from tpc_plugin_validator.lexer.utilities.token_name import TokenName
 
 
 class CPMParameter(RuleSet):
     """Handle validation of the parameter validations."""
+
+    CONFIG_KEY='cpm_parameter_validation'
+    VALID_TOKEN_TYPES={TokenName.COMMENT.value, TokenName.CPM_PARAMETER_VALIDATION.value,}
 
     def validate(self) -> None:
         """Validate the parameter validations in the process file."""
@@ -39,32 +43,29 @@ class CPMParameter(RuleSet):
         """
         if token.token_name != 'CPM Parameter Validation':
             return
+
+        allowed_missing: set[str] = {
+            'ProcessFileName',
+            'PromptsFileName',
+        }
+
+        if token.name in allowed_missing:
+            return
+
         for condition in self._prompts_content.get('conditions', {}):
             if condition.token_name != 'Assignment':
+                continue
+            if condition.assigned and f'<{token.name}>' in condition.assigned:
                 return
-            if f'<{token.name}>' in condition.assigned:
-                return
+
         for state in self._process_content.get('states', {}):
-            if f'<{token.name}>' in state.assigned:
+            if state.token_name != 'Assignment':
+                continue
+            if state.assigned and f'<{token.name}>' in state.assigned:
                 return
+
         self._add_violation(
             name='CPMParameterUnusedParameterViolation',
             description=f'The parameter "{token.name}" is validated but is not used, found on line {token.line_number}.',
             severity=Severity.WARNING,
         )
-
-    def _get_config_key(self) -> str:
-        """
-        Property to identify the config key to use for the rule set.
-
-        :return: The config key as a string.
-        """
-        return 'cpm_parameter_validation'
-
-    def _get_valid_token_types(self) -> set[str]:
-        """
-        Provide a set of token types allowed in the section being analysed.
-
-        :return: Set of token types.
-        """
-        return {'Comment', 'CPM Parameter Validation',}

--- a/tpc_plugin_validator/rule_sets/cpm_parameter.py
+++ b/tpc_plugin_validator/rule_sets/cpm_parameter.py
@@ -52,13 +52,13 @@ class CPMParameter(RuleSet):
         if token.name in allowed_missing:
             return
 
-        for condition in self._prompts_content.get('conditions', {}):
+        for condition in self._prompts_content.get('conditions', []):
             if condition.token_name != 'Assignment':
                 continue
             if condition.assigned and f'<{token.name}>' in condition.assigned:
                 return
 
-        for state in self._process_content.get('states', {}):
+        for state in self._process_content.get('states', []):
             if state.token_name != 'Assignment':
                 continue
             if state.assigned and f'<{token.name}>' in state.assigned:

--- a/tpc_plugin_validator/rule_sets/logging.py
+++ b/tpc_plugin_validator/rule_sets/logging.py
@@ -7,6 +7,8 @@ from tpc_plugin_validator.utilities.severity import Severity
 class Logging(RuleSet):
     """ Validate the logging settings in the process file. """
 
+    CONFIG_KEY='logging'
+
     def validate(self) -> None:
         """Validate the logging settings in the process file."""
         if 'Debug Information' not in self._process_content.keys():
@@ -99,19 +101,3 @@ class Logging(RuleSet):
                 description=f'The logging value for "{token.name}" is set to "{token.assigned}". It is recommended to set all logging settings to "no" for production environments.',
                 severity=Severity.CRITICAL if self._config.get('enabled', True) else Severity.INFO,
             )
-
-    def _get_config_key(self) -> str:
-        """
-        Property to identify the config key to use for the rule set.
-
-        :return: The config key as a string.
-        """
-        return 'logging'
-
-    def _get_valid_token_types(self) -> set[str]:
-        """
-        Provide a set of token types allowed in the section being analysed.
-
-        :return: Set of token types.
-        """
-        return {'Assignment', 'Comment',}

--- a/tpc_plugin_validator/rule_sets/prompts.py
+++ b/tpc_plugin_validator/rule_sets/prompts.py
@@ -8,6 +8,8 @@ from tpc_plugin_validator.utilities.severity import Severity
 class Prompts(RuleSet):
     """ Validate the logging settings in the process file. """
 
+    CONFIG_KEY='prompts'
+
     def validate(self) -> None:
         """Validate the prompts in the prompts file."""
         self._check_valid_sections()
@@ -96,19 +98,3 @@ class Prompts(RuleSet):
                     description=f'An invalid section "{section_name}" has been found in the prompt file.',
                     severity=Severity.WARNING,
                 )
-
-    def _get_config_key(self) -> str:
-        """
-        Property to identify the config key to use for the rule set.
-
-        :return: The config key as a string.
-        """
-        return 'prompts'
-
-    def _get_valid_token_types(self) -> set[str]:
-        """
-        Provide a set of token types allowed in the section being analysed.
-
-        :return: Set of token types.
-        """
-        return {'Assignment', 'Comment',}

--- a/tpc_plugin_validator/rule_sets/rule_set.py
+++ b/tpc_plugin_validator/rule_sets/rule_set.py
@@ -1,12 +1,14 @@
 """Parent class for rule sets."""
 from abc import ABC, abstractmethod
 
+from tpc_plugin_validator.lexer.utilities.token_name import TokenName
 from tpc_plugin_validator.utilities.severity import Severity
 from tpc_plugin_validator.utilities.validation_result import ValidationResult
 
 
 class RuleSet(ABC):
     """Parent class for rule sets."""
+
     __slots__ = (
         '_config',
         '_process_content',
@@ -14,6 +16,8 @@ class RuleSet(ABC):
         '_violations',
     )
 
+    CONFIG_KEY=''
+    VALID_TOKEN_TYPES={TokenName.ASSIGNMENT.value, TokenName.COMMENT.value,}
 
     def __init__(self, process, prompts, config: dict[str, dict[str, bool | int | str]]) -> None:
         """
@@ -23,7 +27,7 @@ class RuleSet(ABC):
         :param prompts: Parsed prompts file.
         :param config: Not used, but included for interface consistency.
         """
-        self._config = config.get(self._get_config_key(), {})
+        self._config = config.get(self.CONFIG_KEY, {})
         self._process_content = process
         self._prompts_content = prompts
         self._violations: list[ValidationResult] = []
@@ -60,21 +64,4 @@ class RuleSet(ABC):
 
         :return: True if valid, Otherwise False.
         """
-        return token.token_name in self._get_valid_token_types()
-
-    @abstractmethod
-    def _get_config_key(self) -> str:
-        """
-        Property to identify the config key to use for the rule set.
-
-        :return: The config key as a string.
-        """
-
-    @abstractmethod
-    def _get_valid_token_types(self) -> set[str]:
-        """
-        Provide a set of token types allowed in the section being analysed.
-
-        :return: Set of token types.
-        """
-
+        return token.token_name in self.VALID_TOKEN_TYPES


### PR DESCRIPTION
Fixes #23 
Fixes #25

## Summary by Sourcery

Refactor rule sets to use a centralized TokenName enum and streamline configuration by replacing abstract methods with class attributes.

Enhancements:
- Centralize token names in a TokenName enum and update all rule sets to reference enum values instead of string literals
- Introduce CONFIG_KEY and VALID_TOKEN_TYPES class attributes in RuleSet and its subclasses, removing _get_config_key and _get_valid_token_types methods
- Simplify token validity checks by using the VALID_TOKEN_TYPES attribute in RuleSet._token_is_valid
- Add CONFIG_KEY declarations to Logging and Prompts rule sets to unify configuration handling
- Enhance CPMParameter rule with an allowed_missing list and refined loops to correctly detect unused parameter validations