### PR TITLE
Fixed a casing issue in a pytest check

### DIFF
--- a/tests/test_logging_rule_sets.py
+++ b/tests/test_logging_rule_sets.py
@@ -62,7 +62,7 @@ class TestLoggingRuleSets(object):
                 ],
             ),
             (
-                'tests/data/OK-logging/process.ini',
+                'tests/data/OK-Logging/process.ini',
                 'tests/data/empty_prompts.ini',
                 True,
                 [],


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix casing mismatch in pytest test path to match actual directory name