### PR TITLE
Updated so that uv runs on pull requests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,10 +1,12 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+  push:
+    branches:
+      - main
   schedule:
     - cron: '21 1 * * 2'
 
@@ -19,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language:
+          - 'python'
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -1,6 +1,9 @@
 name: UV
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary by Sourcery

Enable GitHub Actions workflows to trigger on pull requests to the main branch and unify their event configurations

CI:
- Allow CodeQL analysis workflow to run on both push and pull_request events for the main branch
- Enable UV workflow to trigger on pull_request events for the main branch