### PR TITLE
Updated Github workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@192325c86100d080feab897ff886c34abd4c83a3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Python


### PR DESCRIPTION
Updated Github workflow dependencies.

## Summary by Sourcery

Pin GitHub Actions dependencies in the CodeQL and uv workflows to immutable commit SHAs.

CI:
- Pin CodeQL autobuild and analyze actions to commit 192325c86100d080feab897ff886c34abd4c83a3
- Update astral-sh/setup-uv action reference to commit b75a909f75acd358c2196fb9a5f1299a9a8868a4