### PR TITLE
Updated regex to use named groups and refactored the names of the states

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -156,9 +156,9 @@ class TestLexer(object):
                         TokenName.STATE_TRANSITION,
                         StateTransition(
                             line_number=1,
-                            from_state='state1',
+                            current_state='state1',
                             condition='condition',
-                            to_state='state2',
+                            next_state='state2',
                         ),
                     ),
                 ],
@@ -170,9 +170,9 @@ class TestLexer(object):
                         TokenName.STATE_TRANSITION,
                         StateTransition(
                             line_number=1,
-                            from_state='state_1',
+                            current_state='state_1',
                             condition='condition2',
-                            to_state='STATE2',
+                            next_state='STATE2',
                         ),
                     ),
                 ],

--- a/tpc_plugin_validator/lexer/lexer.py
+++ b/tpc_plugin_validator/lexer/lexer.py
@@ -64,9 +64,9 @@ class Lexer(object):
 
         :param match: Regex match of the assignment.
         """
-        name: str = str(match[1]).strip()
-        equals = str(match[2]).strip() if match[2] else None
-        assigned_stripped = str(match[3]).strip() if match[3] else None
+        name: str = str(match['name']).strip()
+        equals = str(match['equals']).strip() if match.groupdict().get('equals', None) else None
+        assigned_stripped = str(match['value']).strip() if match.groupdict().get('value', None) else None
         assigned = assigned_stripped or None
         self._parsed_data.append(
             (
@@ -90,7 +90,7 @@ class Lexer(object):
             (
                 TokenName.COMMENT,
                 Comment(
-                    content=str(match[1]).strip(),
+                    content=str(match['comment']).strip(),
                     line_number=line_number,
                 )
             )
@@ -129,9 +129,9 @@ class Lexer(object):
             (
                 TokenName.FAIL_STATE,
                 FailState(
-                    name=str(match[1]),
-                    message=str(match[2]).strip(),
-                    code=int(match[3]),
+                    name=str(match['name']).strip(),
+                    message=str(match['message']).strip(),
+                    code=int(match['code']),
                     line_number=line_number,
                 )
             )
@@ -147,7 +147,7 @@ class Lexer(object):
             (
                 TokenName.SECTION_HEADER,
                 SectionHeader(
-                    name=str(match[1]),
+                    name=str(match['name'].strip()),
                     line_number=line_number,
                 )
             )
@@ -163,9 +163,9 @@ class Lexer(object):
             (
                 TokenName.STATE_TRANSITION,
                 StateTransition(
-                    from_state=str(match[1]),
-                    condition=str(match[2]),
-                    to_state=str(match[3]),
+                    current_state=str(match['current']).strip(),
+                    condition=str(match['condition']).strip(),
+                    next_state=str(match['next']).strip(),
                     line_number=line_number,
                 )
             )

--- a/tpc_plugin_validator/lexer/tokens/state_transition.py
+++ b/tpc_plugin_validator/lexer/tokens/state_transition.py
@@ -8,7 +8,7 @@ from tpc_plugin_validator.lexer.utilities.token_name import TokenName
 class StateTransition(object):
     """Dataclass to hold state transitions."""
     line_number: int
-    from_state: str
+    current_state: str
     condition: str
-    to_state: str
+    next_state: str
     token_name: str = TokenName.STATE_TRANSITION.value

--- a/tpc_plugin_validator/lexer/utilities/regex.py
+++ b/tpc_plugin_validator/lexer/utilities/regex.py
@@ -1,9 +1,9 @@
 """List of regex the lexer uses."""
 
 
-ASSIGNMENT = r'^(?:[\s]*)([\w]+)(?:(?:[\s]*)(=)((?:[\s]*)(((?!\s*fail\s*\().)+))?)?(?:[\s]*)$'
-COMMENT = r'^(?:[\s]*)((?:[#;]+)(?:.*))(?:[\s]*)$'
+ASSIGNMENT = r'^(?:[\s]*)(?P<name>[\w]+)(?:(?:[\s]*)(?P<equals>=)(?:(?:[\s]*)(?P<value>(?:(?!\s*fail\s*\().)+))?)?(?:[\s]*)$'
+COMMENT = r'^(?:[\s]*)(?P<comment>(?:[#;]+)(?:.*))(?:[\s]*)$'
 CPM_PARAMETER_VALIDATION = r'^(?:[\s]*)(?P<name>[\w\\]+)(?:(?:[\s]*,[\s]*)(?:source)(?:[\s]*)=(?:[\s]*)(?P<source>[^, ]*))(?:(?:[\s]*,[\s]*)(?:mandatory)(?:[\s]*)=(?:[\s]*)(?P<mandatory>[^,]*))?(?:(?:[\s]*,[\s]*)(?:allowcharacters)(?:[\s]*)=(?:[\s]*)(?P<allowcharacters>.*))?$'
-FAIL_STATE = r'^(?:[\s]*)([\w]+)(?:[\s]*)=(?:[\s]*)(?:[\s]*)(?:fail)(?:[\s]*)\((?:[\s]*)(.*)(?:[\s])?,(?:[\s]*)([0-9]+)\)(?:[\s]*)$'
-SECTION_HEADER = r'^(?:[\s]*)\[([\w]+(?:[\s]+[\w]+)*)](?:[\s]*)$'
-TRANSITION = r'^(?:[\s]*)([\w]+)(?:[\s]*,[\s]*)([\w]+)(?:[\s]*,[\s]*)([\w]+)(?:[\s]*)$'
+FAIL_STATE = r'^(?:[\s]*)(?P<name>[\w]+)(?:[\s]*)=(?:[\s]*)(?:[\s]*)(?:fail)(?:[\s]*)\((?:[\s]*)(?P<message>.*)(?:[\s])?,(?:[\s]*)(?P<code>[0-9]+)\)(?:[\s]*)$'
+SECTION_HEADER = r'^(?:[\s]*)\[(?P<name>[\w]+(?:[\s]+[\w]+)*)](?:[\s]*)$'
+TRANSITION = r'^(?:[\s]*)(?P<current>[\w]+)(?:[\s]*,[\s]*)(?P<condition>[\w]+)(?:[\s]*,[\s]*)(?P<next>[\w]+)(?:[\s]*)$'

--- a/tpc_plugin_validator/rule_sets/transitions.py
+++ b/tpc_plugin_validator/rule_sets/transitions.py
@@ -47,7 +47,7 @@ class Transitions(RuleSet):
         )
         state_transitions_joined: list[str] = []
         state_transitions_joined.extend(
-            f'{state_transition.from_state},{state_transition.condition},{state_transition.to_state}'
+            f'{state_transition.current_state},{state_transition.condition},{state_transition.next_state}'
             for state_transition in state_transitions
         )
 
@@ -77,22 +77,22 @@ class Transitions(RuleSet):
         """
         if transition.token_name != TokenName.STATE_TRANSITION.value:
             return
-        if transition.to_state.lower() == 'end':
+        if transition.next_state.lower() == 'end':
             return
         from_states: list[str] = []
         from_states.extend(
-            value.from_state
+            value.current_state
             for value in transitions
             if value.token_name == TokenName.STATE_TRANSITION.value
         )
-        if transition.to_state not in from_states:
-            fail_state_token: Assignment | None = self._get_fail_state(transition.to_state)
+        if transition.next_state not in from_states:
+            fail_state_token: Assignment | None = self._get_fail_state(transition.next_state)
             if fail_state_token and fail_state_token.token_name == TokenName.FAIL_STATE.value:
                 # failure condition, nothing follows this.
                 return
             self._add_violation(
                 name='TransitionsStateTransitionViolation',
-                description=f'The state "{transition.to_state}" does not have a valid state to transition too.',
+                description=f'The state "{transition.next_state}" does not have a valid state to transition too.',
                 severity=Severity.WARNING,
             )
 
@@ -105,19 +105,19 @@ class Transitions(RuleSet):
         """
         if transition.token_name != TokenName.STATE_TRANSITION.value:
             return
-        if transition.from_state.lower() == 'init':
+        if transition.current_state.lower() == 'init':
             return
         to_states: list[str] = []
         to_states.extend(
-            value.to_state
+            value.next_state
             for value in transitions
             if value.token_name == TokenName.STATE_TRANSITION.value
         )
         to_states_set = set(to_states)
-        if transition.from_state not in to_states_set:
+        if transition.current_state not in to_states_set:
             self._add_violation(
                 name='TransitionsStateTransitionViolation',
-                description=f'The state "{transition.from_state}" does not have a valid state to transition from.',
+                description=f'The state "{transition.current_state}" does not have a valid state to transition from.',
                 severity=Severity.WARNING,
             )
 


### PR DESCRIPTION
Updated the regex to use named groups rather than indexes to make them easier to digest.

Also updated from_state and to_state so that they better match CyberArk terminology.

## Summary by Sourcery

Improve regex maintainability by switching to named capture groups and align state transition naming to CyberArk terminology by renaming from_state/to_state to current_state/next_state throughout the lexer, rule sets, and tests.

Enhancements:
- Convert regex patterns to use named capture groups for improved readability
- Refactor lexer methods to extract named groups instead of numeric indices
- Rename StateTransition attributes from from_state/to_state to current_state/next_state across codebase

Tests:
- Update lexer tests to use renamed current_state and next_state fields