### PR TITLE
Implemented capture of unparsed lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyberark-tpc-plugin-validator"
-version = "0.2.0"
+version = "0.3.0"
 description = "A tool to help validate a custom TPC plugin."
 authors = [{ name = "Peter McDonald", email = "git@petermcdonald.co.uk"}]
 readme = "README.md"

--- a/tests/data/invalid-process.ini
+++ b/tests/data/invalid-process.ini
@@ -78,7 +78,7 @@ ExpectLog=yes
 COnsoleOutput=No
 InvalidName=Dummy
 COnsoleOutput=No
-
+I cant be parsed
 
 
 

--- a/tests/test_debug_information_section_rule_set.py
+++ b/tests/test_debug_information_section_rule_set.py
@@ -80,6 +80,11 @@ class TestDebugInformationSectionRuleSet(object):
                         severity=Severity.CRITICAL,
                         message='The assignment "COnsoleOutput" has been declared 2 times, file: process.ini, section: Debug Information.',
                     ),
+                    ValidationResult(
+                        rule="ParseErrorViolation",
+                        severity=Severity.CRITICAL,
+                        message='Line could not be parsed, file: process.ini, section: Debug Information, line: 81.',
+                    ),
                 ],
             ),
         ],

--- a/tests/test_debug_information_section_rule_set.py
+++ b/tests/test_debug_information_section_rule_set.py
@@ -83,7 +83,7 @@ class TestDebugInformationSectionRuleSet(object):
                     ValidationResult(
                         rule="ParseErrorViolation",
                         severity=Severity.CRITICAL,
-                        message='Line could not be parsed, file: process.ini, section: Debug Information, line: 81.',
+                        message="Line could not be parsed, file: process.ini, section: Debug Information, line: 81.",
                     ),
                 ],
             ),

--- a/tpc_plugin_validator/lexer/tokens/parse_error.py
+++ b/tpc_plugin_validator/lexer/tokens/parse_error.py
@@ -1,0 +1,14 @@
+"""Class to hold a parse error token."""
+
+from dataclasses import dataclass
+
+from tpc_plugin_validator.lexer.utilities.token_name import TokenName
+
+
+@dataclass(frozen=True)
+class ParseError(object):
+    """Dataclass to hold sparse errors."""
+
+    line_number: int
+    content: str
+    token_name: str = TokenName.PARSE_ERROR.value

--- a/tpc_plugin_validator/lexer/utilities/token_name.py
+++ b/tpc_plugin_validator/lexer/utilities/token_name.py
@@ -10,5 +10,6 @@ class TokenName(Enum):
     COMMENT = "Comment"
     FAIL_STATE = "Fail State"
     CPM_PARAMETER_VALIDATION = "CPM Parameter Validation"
+    PARSE_ERROR = "Parse Error"
     SECTION_HEADER = "Section Header"
     TRANSITION = "Transition"

--- a/tpc_plugin_validator/lexer/utilities/types.py
+++ b/tpc_plugin_validator/lexer/utilities/types.py
@@ -9,11 +9,12 @@ from tpc_plugin_validator.lexer.tokens.cpm_parameter_validation import (
     CPMParameterValidation,
 )
 from tpc_plugin_validator.lexer.tokens.fail_state import FailState
+from tpc_plugin_validator.lexer.tokens.parse_error import ParseError
 from tpc_plugin_validator.lexer.tokens.section_header import SectionHeader
 from tpc_plugin_validator.lexer.tokens.transition import Transition
 from tpc_plugin_validator.lexer.utilities.token_name import TokenName
 
-ALL_TOKEN_TYPES = Assignment | Comment | FailState | CPMParameterValidation | SectionHeader | Transition
+ALL_TOKEN_TYPES = Assignment | Comment | FailState | CPMParameterValidation | ParseError | SectionHeader | Transition
 
 
 class TokenSpecs(TypedDict):

--- a/tpc_plugin_validator/parser/parser.py
+++ b/tpc_plugin_validator/parser/parser.py
@@ -11,17 +11,15 @@ class Parser(object):
 
     __slots__ = (
         "_process_file",
-        "_process_file_path",
         "_prompts_file",
-        "_prompts_file_path",
     )
 
     def __init__(self, process_file: str, prompts_file: str) -> None:
         """
         Initializes the Parser with the given process and prompts files.
 
-        :param process_file (str): Path to the process configuration file.
-        :param prompts_file (str): Path to the prompt configuration file.
+        :param process_file (str): Content of the process file.
+        :param prompts_file (str): Content of the prompts file.
         """
 
         process_lexer = Lexer(source=process_file)

--- a/tpc_plugin_validator/rule_sets/rule_set.py
+++ b/tpc_plugin_validator/rule_sets/rule_set.py
@@ -2,6 +2,7 @@
 
 from abc import ABC
 
+from tpc_plugin_validator.lexer.utilities.token_name import TokenName
 from tpc_plugin_validator.utilities.exceptions import ProgrammingError
 from tpc_plugin_validator.utilities.severity import Severity
 from tpc_plugin_validator.utilities.types import CONFIG_TYPE, FileNames, SectionNames, Violations
@@ -143,7 +144,19 @@ class RuleSet(ABC):
             return
 
         for token in section:
-            if token.token_name not in self._VALID_TOKENS:
+            if token.token_name == TokenName.PARSE_ERROR.value:
+                message: str = self._create_message(
+                    message='Line could not be parsed',
+                    file=file,
+                    section=required_section,
+                    line_number=token.line_number,
+                )
+                self._add_violation(
+                    name=Violations.parse_error_violation,
+                    description=message,
+                    severity=Severity.CRITICAL,
+                )
+            elif token.token_name not in self._VALID_TOKENS:
                 message: str = self._create_message(
                     message=f'The token type "{token.token_name}" is not valid in this section',
                     file=file,

--- a/tpc_plugin_validator/rule_sets/rule_set.py
+++ b/tpc_plugin_validator/rule_sets/rule_set.py
@@ -146,7 +146,7 @@ class RuleSet(ABC):
         for token in section:
             if token.token_name == TokenName.PARSE_ERROR.value:
                 message: str = self._create_message(
-                    message='Line could not be parsed',
+                    message="Line could not be parsed",
                     file=file,
                     section=required_section,
                     line_number=token.line_number,

--- a/tpc_plugin_validator/utilities/exceptions.py
+++ b/tpc_plugin_validator/utilities/exceptions.py
@@ -1,12 +1,6 @@
 """Custom exceptions."""
 
 
-class LexerException(Exception):
-    """Raised when a lexer error occurs."""
-
-    pass
-
-
 class ProgrammingError(Exception):
     """Raised when an error occurs due to a programming error."""
 

--- a/tpc_plugin_validator/utilities/types.py
+++ b/tpc_plugin_validator/utilities/types.py
@@ -46,6 +46,7 @@ class Violations(Enum):
     name_case_mismatch_violation = "NameCaseMismatchViolation"
     name_case_violation = "NameCaseViolation"
     name_violation = "NameViolation"
+    parse_error_violation = "ParseErrorViolation"
     section_name_case_violation = "SectionNameCaseViolation"
     unused_condition_violation = "UnusedConditionViolation"
     unused_parameter_violation = "UnusedParameterViolation"

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ toml = [
 
 [[package]]
 name = "cyberark-tpc-plugin-validator"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary by Sourcery

Implement handling of unparsed lines by emitting ParseError tokens throughout the lexer and rule validation, replace LexerException with token-based errors, update tests accordingly, and bump version to 0.3.0.

New Features:
- Capture unparsed lines as ParseError tokens instead of raising exceptions
- Add a ParseError token class and include it in the lexer's token types

Enhancements:
- Rename Lexer internal storage from _parsed_data to _tokens
- Extend ALL_TOKEN_TYPES and TokenName enum to support ParseError
- Update rule set to emit a critical parse_error_violation for ParseError tokens
- Clarify Parser docstrings to indicate content-based inputs

Build:
- Bump project version to 0.3.0

Tests:
- Refactor tests to expect ParseError tokens for unmatched lines instead of exceptions