### PR TITLE
Added check in CPMParametersValidationSectionRuleSet to stop when the…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyberark-tpc-plugin-validator"
-version = "0.4.0"
+version = "0.4.1"
 description = "A tool to help validate a custom TPC plugin."
 authors = [{ name = "Peter McDonald", email = "git@petermcdonald.co.uk"}]
 readme = "README.md"

--- a/tpc_plugin_validator/rule_sets/cpm_parameters_validation_section_rule_set.py
+++ b/tpc_plugin_validator/rule_sets/cpm_parameters_validation_section_rule_set.py
@@ -80,6 +80,9 @@ class CPMParametersValidationSectionRuleSet(SectionRuleSet):
         """
 
         conditions = self._get_section(file=FileNames.prompts, section_name=SectionNames.conditions)
+        if not conditions:
+            return False
+
         for condition in conditions:
             if condition.token_name != TokenName.ASSIGNMENT.value:
                 continue


### PR DESCRIPTION
… section doesnt exist

fixes #51

## Summary by Sourcery

Add an early exit in CPMParametersValidationSectionRuleSet._validate_token_utilised to handle missing conditions section and bump version to 0.4.1

Bug Fixes:
- Stop validation and return False when the conditions section is missing in CPMParametersValidationSectionRuleSet

Build:
- Bump project version from 0.4.0 to 0.4.1