### PR TITLE
Updated transitions section rule set to allow non Init entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 dependencies = [
-    "cyberark-tpc-plugin-parser>=0.1.0",
+    "cyberark-tpc-plugin-parser>=0.2.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/data/invalid-process.ini
+++ b/tests/data/invalid-process.ini
@@ -11,7 +11,7 @@ Init,      hello,     wait
 # Comment.
 ; Alternative comment.
 Init,      hello,     wait
-Init
+Begin
 Wait=sleep 1
 IsWaiting
 SomeFailure=FAIL(We failed for some reason., 123)
@@ -30,13 +30,13 @@ source=FILE
 [Transitions]
 # Comment.
 ; Alternative comment.
-Init,      hello,              wait
+Begin,     hello,              wait
 wait,      waiting,            IsWaiting
 wait,      failure,            SomeFailure
 wait,      ForInvalidNext,     NoNext
 NoPrevious,ForInvalidPrevious, END
 IsWaiting, goodbye,            END
-Init,      hello,              wait
+Begin,     hello,              wait
 Dummy=Hello
 IsWaiting, sql2,            END
 

--- a/tests/test_transitions_section_rule_set.py
+++ b/tests/test_transitions_section_rule_set.py
@@ -33,7 +33,7 @@ class TestTransitionsSectionRuleSet(object):
                     ValidationResult(
                         rule="DuplicateTransitionViolation",
                         severity=Severity.WARNING,
-                        message='The transition "Init,hello,wait" has been declared 2 times, a transition tuple must be unique, file: process.ini, section: transitions.',
+                        message='The transition "Begin,hello,wait" has been declared 2 times, a transition tuple must be unique, file: process.ini, section: transitions.',
                     ),
                     ValidationResult(
                         rule="InvalidTransitionViolation",
@@ -44,6 +44,11 @@ class TestTransitionsSectionRuleSet(object):
                         rule="InvalidTransitionViolation",
                         severity=Severity.CRITICAL,
                         message='The state "NoPrevious" does not have a valid path leading to it, file: process.ini, section: transitions, line: 37.',
+                    ),
+                    ValidationResult(
+                        rule="NameViolation",
+                        severity=Severity.WARNING,
+                        message='The start state "Begin" for clarity should be called "Init", file: process.ini, section: transitions, line: 33.',
                     ),
                 ],
             ),

--- a/uv.lock
+++ b/uv.lock
@@ -114,16 +114,16 @@ toml = [
 
 [[package]]
 name = "cyberark-tpc-plugin-parser"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/09/52e72e46a55ca31559b16f6ab154766ec3715d1d811eefa8cd98b6a86e48/cyberark_tpc_plugin_parser-0.1.0.tar.gz", hash = "sha256:e6c872b61bd536113de87d1973347bacff592a2c3ec737bc9ba2d5a046c6eca8", size = 7625, upload-time = "2025-09-28T21:30:23.962Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/04/f2cb083c5e0e45e7da9c1a19953a101d369588b4118b3dd6da9ed4be4fec/cyberark_tpc_plugin_parser-0.2.0.tar.gz", hash = "sha256:31a6081e3d5c8a3d5809a625620ab9239704ce936beb4204082be10ddfcb9382", size = 7900, upload-time = "2025-10-05T13:18:17.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/21/46d8ffdba6dba8983aebab62a1e01ddb8587abcd9f5d65b52f00c3cd502d/cyberark_tpc_plugin_parser-0.1.0-py3-none-any.whl", hash = "sha256:30b64a0f133f92c13832f2c6a28ff35d0015a93eee5e981fbb96158ec64d39be", size = 11510, upload-time = "2025-09-28T21:30:22.754Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/4f/2ca7f74ef6fd1b79f9bd35e0c0ec97a477d5f39a32a14335e8499bedd653/cyberark_tpc_plugin_parser-0.2.0-py3-none-any.whl", hash = "sha256:7b1c4beeea77d54b2ded963addd005d4c51b7acb12d1e6e604bd57d114b3ede4", size = 11972, upload-time = "2025-10-05T13:18:16.866Z" },
 ]
 
 [[package]]
 name = "cyberark-tpc-plugin-validator"
-version = "0.6.1"
+version = "0.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "cyberark-tpc-plugin-parser" },
@@ -140,7 +140,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cyberark-tpc-plugin-parser", specifier = ">=0.1.0" }]
+requires-dist = [{ name = "cyberark-tpc-plugin-parser", specifier = ">=0.2.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Updated code so that it allows entry points that are called anything other than Init but will warn.

Also updated to the latest version of CyberArk-TPC-Plugin-Parser

Fixes #65

## Summary by Sourcery

Allow custom entry points in transitions section and warn when a non-default initial state is used, and bump the parser dependency version.

Enhancements:
- Permit entry points named other than Init in the transitions rule set and emit a one-time warning for clarity

Build:
- Upgrade cyberark-tpc-plugin-parser dependency to version >=0.2.0

Tests:
- Adjust transitions section tests to expect a warning for custom initial states