### PR TITLE
Improved __str__ output for ValidationResults

### DIFF
--- a/tests/data/transitions-invalid-process.ini
+++ b/tests/data/transitions-invalid-process.ini
@@ -24,7 +24,7 @@ Wait,           Waiting,    SetPassword
 IsWaiting,      SQL,        END
 IsWaiting,      TRUE,       SetPassword
 Wait,           Failure,    SomeFailure
-Wait,           Failure,    SomeFailure
+Wait,           failure,    SomeFailure
 NoPrevious,     Failure,    SomeFailure
 Wait,           Nothing,    NoNext
 SetPassword,    Goodbye,    END

--- a/tests/data/valid-process.ini
+++ b/tests/data/valid-process.ini
@@ -35,8 +35,6 @@ ProcessFileName, source=FILE, Mandatory=yes
 # Comment.
 ; Alternative comment.
 PromptTimeout=60
-SendHumanMin=1
-SendHumanMax=2
 
 [Debug Information]
 # Comment.

--- a/tests/test_transitions_section_rule_set.py
+++ b/tests/test_transitions_section_rule_set.py
@@ -21,7 +21,7 @@ class TestTransitionsSectionRuleSet(object):
                     ValidationResult(
                         rule="DuplicateTransitionViolation",
                         severity=Severity.CRITICAL,
-                        message='The transition "Wait,Failure,SomeFailure" has been declared 2 times, a transition triple must be unique.',
+                        message='The transition "wait,failure,somefailure" has been declared 2 times, a transition triple must be unique.',
                         file="process.ini",
                         section="transitions",
                     ),
@@ -60,6 +60,14 @@ class TestTransitionsSectionRuleSet(object):
                         file="process.ini",
                         section="transitions",
                         line=24,
+                    ),
+                    ValidationResult(
+                        rule="NameCaseMismatchViolation",
+                        severity=Severity.WARNING,
+                        message='The condition "Failure" is declared but is used as "failure".',
+                        file="process.ini",
+                        section="transitions",
+                        line=27,
                     ),
                     # Test to ensure that states used in transitions have been declared.
                     ValidationResult(

--- a/tests/test_validation_result.py
+++ b/tests/test_validation_result.py
@@ -1,0 +1,62 @@
+"""Tests for the ValidationResult object."""
+
+import pytest
+
+from tpc_plugin_validator.utilities.severity import Severity
+from tpc_plugin_validator.utilities.validation_result import ValidationResult
+
+
+class TestTransitionsSectionRuleSet(object):
+    """Tests for the ValidationResult object."""
+
+    @pytest.mark.parametrize(
+        "validation_result,expected_message",
+        [
+            (
+                ValidationResult(
+                    rule="InvalidTokenTypeViolation",
+                    severity=Severity.CRITICAL,
+                    message='The token type "Transition" is not valid in the "default" section.',
+                    file="process.ini",
+                    section="default",
+                    line=7,
+                ),
+                'CRITICAL - process.ini:default(7) (InvalidTokenTypeViolation) The token type "Transition" is not valid in the "default" section.',
+            ),
+            (
+                ValidationResult(
+                    rule="SectionNameCaseViolation",
+                    severity=Severity.WARNING,
+                    message='The section "conditions" has been declared as "Conditions".',
+                    file="prompts.ini",
+                    section="conditions",
+                ),
+                'WARNING - prompts.ini:conditions (SectionNameCaseViolation) The section "conditions" has been declared as "Conditions".',
+            ),
+            (
+                ValidationResult(
+                    rule="InvalidSectionNameViolation",
+                    severity=Severity.WARNING,
+                    message='The section "Dummy Section" has been declared but is an invalid section name.',
+                    file="process.ini",
+                ),
+                'WARNING - process.ini (InvalidSectionNameViolation) The section "Dummy Section" has been declared but is an invalid section name.',
+            ),
+            (
+                ValidationResult(
+                    rule="InvalidSectionNameViolation",
+                    severity=Severity.INFO,
+                    message='The section "Dummy Section" has been declared but is an invalid section name.',
+                ),
+                'INFO - (InvalidSectionNameViolation) The section "Dummy Section" has been declared but is an invalid section name.',
+            ),
+        ],
+    )
+    def test_validation_result(self, validation_result: ValidationResult, expected_message: str) -> None:
+        """
+        Tests for the ValidationResult object.
+
+        :param validation_result: Instance of ValidationResult object.
+        :param expected_message: Expected message.
+        """
+        assert str(validation_result) == expected_message

--- a/tpc_plugin_validator/rule_sets/transitions_section_rule_set.py
+++ b/tpc_plugin_validator/rule_sets/transitions_section_rule_set.py
@@ -121,7 +121,7 @@ class TransitionsSectionRuleSet(SectionRuleSet):
         )
         state_transitions_joined: list[str] = []
         state_transitions_joined.extend(
-            f"{state_transition.current_state},{state_transition.condition},{state_transition.next_state}"
+            f"{state_transition.current_state},{state_transition.condition},{state_transition.next_state}".lower()
             for state_transition in state_transitions
         )
 
@@ -173,7 +173,7 @@ class TransitionsSectionRuleSet(SectionRuleSet):
         """
         Check the previous token is valid for the transition.
 
-        :param transition: The transitions token to check.
+        :param transition: The transition token to check.
         :param transitions: A list of all the transitions.
         """
         if transition.token_name != TokenName.TRANSITION.value:

--- a/tpc_plugin_validator/utilities/validation_result.py
+++ b/tpc_plugin_validator/utilities/validation_result.py
@@ -18,13 +18,12 @@ class ValidationResult(object):
 
     def __str__(self):
         """String representation of the validation result."""
-        output_message: str = f"{self.severity}: ({self.rule}) {self.message}"
+        file_details = ""
         if self.file is not None:
-            output_message += f", file: {self.file}"
+            file_details += f" {self.file}"
         if self.section is not None:
-            output_message += f", section: {self.section}"
+            file_details += f":{self.section}"
         if self.line is not None:
-            output_message += f", line: {self.line}"
-        if any([self.file, self.section, self.line]):
-            output_message += "."
+            file_details += f"({self.line})"
+        output_message: str = f"{self.severity.value} -{file_details} ({self.rule}) {self.message}"
         return output_message

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,7 @@ wheels = [
 
 [[package]]
 name = "cyberark-tpc-plugin-validator"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cyberark-tpc-plugin-parser" },


### PR DESCRIPTION
fixes #78

## Summary by Sourcery

Improve ValidationResult string formatting and enhance transition duplicate detection by enforcing lowercase comparisons, with corresponding updates to tests and fixtures

Enhancements:
- Standardize ValidationResult __str__ output to include optional file, section, and line in the format 'SEVERITY - file:section(line) (rule) message'
- Make duplicate transition detection case-insensitive by lowercasing transition triples

Documentation:
- Correct docstring parameter name in transitions_section_rule_set

Tests:
- Add parameterized tests for ValidationResult __str__ output across various scenarios
- Update existing transition tests and fixtures to reflect lowercase transition values and new name case mismatch validation

Chores:
- Remove obsolete entries from valid-process.ini test fixture