### PR TITLE
Added check to ensure transitions are not declared after a previous b…oolean transitoons with the same current_state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cyberark-tpc-plugin-validator"
-version = "0.8.1"
+version = "0.9.0"
 description = "A tool to help validate a custom TPC plugin."
 keywords = ["cyberark", "validate", "tpc"]
 authors = [{ name = "Peter McDonald", email = "git@petermcdonald.co.uk"}]

--- a/tests/data/transitions-invalid-process.ini
+++ b/tests/data/transitions-invalid-process.ini
@@ -18,16 +18,18 @@ END
 [transitions]
 # Comment.
 ; Alternative comment.
-Begin,          Hello,      wait
-wait,           Waiting,    IsWaiting
-Wait,           Waiting,    SetPassword
-IsWaiting,      SQL,        END
-IsWaiting,      TRUE,       SetPassword
-Wait,           Failure,    SomeFailure
-Wait,           failure,    SomeFailure
-NoPrevious,     Failure,    SomeFailure
-Wait,           Nothing,    NoNext
-SetPassword,    Goodbye,    END
+Begin,          Hello,             wait
+wait,           Waiting,           IsWaiting
+Wait,           Waiting,           SetPassword
+IsWaiting,      SQL,               END
+IsWaiting,      TRUE,              SetPassword
+IsWaiting,      Waiting,           END
+Wait,           Failure,           SomeFailure
+Wait,           failure,           SomeFailure
+NoPrevious,     Failure,           SomeFailure
+Wait,           AnotherExpression, END
+Wait,           Nothing,           NoNext
+SetPassword,    Goodbye,           END
 SetPassword=<password>
 I cant be parsed
 

--- a/tests/data/transitions-invalid-prompts.ini
+++ b/tests/data/transitions-invalid-prompts.ini
@@ -14,3 +14,4 @@ Goodbye=Goodbye
 Failure=Some Failure
 TRUE=(expression)true
 Nothing=Nothing
+AnotherExpression=(expression)false

--- a/tests/test_transitions_section_rule_set.py
+++ b/tests/test_transitions_section_rule_set.py
@@ -61,13 +61,23 @@ class TestTransitionsSectionRuleSet(object):
                         section="transitions",
                         line=24,
                     ),
+                    # Test to ensure that transitions that cannot be reached are caught.
+                    ValidationResult(
+                        rule="UnreachableTransitionViolation",
+                        severity=Severity.CRITICAL,
+                        message='The transition "IsWaiting,Waiting,END" is unreachable due to a previous transition from "IsWaiting" having a boolean condition.',
+                        file="process.ini",
+                        section="transitions",
+                        line=26,
+                    ),
+                    # Test to ensure states in transitions are in the same case as they are declared.
                     ValidationResult(
                         rule="NameCaseMismatchViolation",
                         severity=Severity.WARNING,
                         message='The condition "Failure" is declared but is used as "failure".',
                         file="process.ini",
                         section="transitions",
-                        line=27,
+                        line=28,
                     ),
                     # Test to ensure that states used in transitions have been declared.
                     ValidationResult(
@@ -76,7 +86,7 @@ class TestTransitionsSectionRuleSet(object):
                         message='The state "NoPrevious" used in the transition current state has not been declared.',
                         file="process.ini",
                         section="transitions",
-                        line=28,
+                        line=29,
                     ),
                     # Test to ensure that transitions can be reached.
                     ValidationResult(
@@ -85,7 +95,7 @@ class TestTransitionsSectionRuleSet(object):
                         message='The state "NoPrevious" does not have a valid transition leading to it.',
                         file="process.ini",
                         section="transitions",
-                        line=28,
+                        line=29,
                     ),
                     # Test to ensure that states in transitions have been declared.
                     ValidationResult(
@@ -94,7 +104,7 @@ class TestTransitionsSectionRuleSet(object):
                         message='The state "NoNext" used in the transition next state has not been declared.',
                         file="process.ini",
                         section="transitions",
-                        line=29,
+                        line=31,
                     ),
                     # Test to ensure that states in transitions have been declared.
                     ValidationResult(
@@ -103,7 +113,16 @@ class TestTransitionsSectionRuleSet(object):
                         message='The state "Wait" attempts to transition to "NoNext" but has not been declared.',
                         file="process.ini",
                         section="transitions",
-                        line=29,
+                        line=31,
+                    ),
+                    # Test to ensure that transitions that cannot be reached are caught.
+                    ValidationResult(
+                        rule="UnreachableTransitionViolation",
+                        severity=Severity.CRITICAL,
+                        message='The transition "Wait,Nothing,NoNext" is unreachable due to a previous transition from "Wait" having a boolean condition.',
+                        file="process.ini",
+                        section="transitions",
+                        line=31,
                     ),
                     # Test invalid token type in transitions section are caught.
                     ValidationResult(
@@ -112,7 +131,7 @@ class TestTransitionsSectionRuleSet(object):
                         message='The token type "Assignment" is not valid in the "transitions" section.',
                         file="process.ini",
                         section="transitions",
-                        line=31,
+                        line=33,
                     ),
                     # Test for ensuring parse errors are caught.
                     ValidationResult(
@@ -121,7 +140,7 @@ class TestTransitionsSectionRuleSet(object):
                         message="Line could not be parsed correctly.",
                         file="process.ini",
                         section="transitions",
-                        line=32,
+                        line=34,
                     ),
                 ],
             ),

--- a/tpc_plugin_validator/utilities/types.py
+++ b/tpc_plugin_validator/utilities/types.py
@@ -53,5 +53,6 @@ class Violations(Enum):
     unused_condition_violation = "UnusedConditionViolation"
     unused_parameter_violation = "UnusedParameterViolation"
     unused_state_violation = "UnusedStateViolation"
+    unreachable_transition_violation = "UnreachableTransitionViolation"
     value_case_violation = "ValueCaseViolation"
     value_violation = "ValueViolation"

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,7 @@ wheels = [
 
 [[package]]
 name = "cyberark-tpc-plugin-validator"
-version = "0.8.0"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cyberark-tpc-plugin-parser" },


### PR DESCRIPTION
Added check to ensure transitions are not declared after a previous b…oolean transitoons with the same current_state

## Summary by Sourcery

Add validation to detect unreachable transitions following a boolean-conditioned transition for the same current state, introduce a new violation type, and update tests and sample configurations accordingly.

New Features:
- Detect and report unreachable transitions that follow a boolean-conditioned transition in the same current state

Enhancements:
- Invoke the new _validate_transition_reachable check in the transitions validation flow

Build:
- Bump project version from 0.8.1 to 0.9.0

Tests:
- Add tests and sample INI data to cover unreachable transitions due to prior boolean conditions