### PR TITLE
Updated CICD dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
           - 'python'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
       - name: Initialize CodeQL
         uses: github/codeql-action/init@16df4fbc19aea13d921737861d6c622bf3cefe23
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867
         with:
           python-version: ${{ matrix.python-version }}
       - name: UV Build

--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -19,11 +19,11 @@ jobs:
           - "3.11"
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41
+        uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Python
@@ -39,7 +39,7 @@ jobs:
       - name: Troml
         run: uv run troml check
       - name: Run SonarQube
-        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
+        uses: sonarsource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
Updated comms points for GitHub actions.

## Summary by Sourcery

Update CI workflows to use newer pinned versions of third-party GitHub Actions.

Build:
- Refresh pinned SHAs for checkout and uv setup actions in build-related workflows.

CI:
- Update checkout, uv setup, and SonarQube scan actions to newer pinned revisions across CI workflows.