### PR TITLE
Added cosmic-ray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.sqlite
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ issues = "https://github.com/petermcd/CyberArk-TPC-Plugin-Validator/issues"
 
 [dependency-groups]
 dev = [
+    "cosmic-ray>=8.4.6",
     "pip-audit>=2.10.0",
     "pygments>=2.20.0", # Pinned to resolve security issue
     "pyright>=1.1.409",
@@ -50,3 +51,12 @@ addopts = "--cov=tpc_plugin_validator --cov-report term-missing --cov-report xml
 
 [tool.ruff]
 line-length = 120
+
+[cosmic-ray]
+module-path = "tpc_plugin_validator"
+timeout = 10.0
+excluded-modules = []
+test-command = "uv run pytest"
+
+[cosmic-ray.distributor]
+name = "local"


### PR DESCRIPTION
Added cosmic-ray configuration

## Summary by Sourcery

Add mutation testing configuration using cosmic-ray and include it in the development dependencies.

Build:
- Add cosmic-ray as a development dependency in the project configuration.

Tests:
- Configure cosmic-ray to run mutation testing against the tpc_plugin_validator package using pytest and a local distributor.